### PR TITLE
Fix incorrect prefix parameter

### DIFF
--- a/configure
+++ b/configure
@@ -80,12 +80,12 @@ do
     --prefix)
       shift
       prefix="$1"
-      includedir=$PREFIX/include
+      includedir=$prefix/include
       shift
       ;;
     --prefix=*)
       prefix="${i#*=}"
-      includedir=$PREFIX/include
+      includedir=$prefix/include
       shift
       ;;
 


### PR DESCRIPTION
`$PREFIX` should be `$prefix`. 

Otherwise, configuring with a custom --prefix="" value fails.

```
$ ./configure --prefix=/tmp/ROOT            
Configuring jeayeson
Platform: Linux
./configure: line 88: PREFIX: unbound variable
```
