### PR TITLE
json_map has method + tests

### DIFF
--- a/include/jeayeson/map.hpp
+++ b/include/jeayeson/map.hpp
@@ -158,6 +158,24 @@ namespace jeayeson
       const_iterator find(key_t const &key) const
       { return values_.find(key); }
 
+      bool has(key_t const &key)
+      { return find(key) != end(); }
+      bool has(key_t const &key) const
+      { return find(key) != end(); }
+
+      template<typename VT>
+      bool has(key_t const &key)
+      {
+        auto it = find(key);
+        return it != end() && it->second.is(Value::template to_value<VT>::value);
+      }
+      template<typename VT>
+      bool has(key_t const &key) const
+      {
+        auto it = find(key);
+        return it != end() && it->second.is(Value::template to_value<VT>::value);
+      }
+
       iterator begin()
       { return values_.begin(); }
       const_iterator begin() const

--- a/test/include/map/has.hpp
+++ b/test/include/map/has.hpp
@@ -1,0 +1,36 @@
+/*
+  Copyright © 2014 Jesse 'Jeaye' Wilkerson
+  See licensing at:
+    http://opensource.org/licenses/BSD-3-Clause
+
+  File: test/include/map/has.hpp
+  Author: Jakub 'kuhar' Kuderski
+*/
+
+#include <jeayeson/jeayeson.hpp>
+#include <jest/jest.hpp>
+
+namespace jeayeson
+{
+  struct map_has_test{};
+  using map_has_group = jest::group<map_has_test>;
+  static map_has_group const map_has_obj{ "map has" };
+}
+
+namespace jest
+{
+  template <> template <>
+  void jeayeson::map_has_group::test<0>()
+  {
+    json_map map{ "{\"foo\":{\"bar\":42,\"spam\":null},\"arr\":[0,1,2]}" };
+
+    expect(map.has("foo"));
+    expect(map.has<json_map>("foo"));
+
+    auto &foo(map.get<json_map>("foo"));
+    expect(foo.has<int>("bar"));
+
+    expect(map.has<json_array>("arr"));
+  }
+}
+ 

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -17,6 +17,7 @@
 #include "map/size.hpp"
 #include "map/clear.hpp"
 #include "map/delim.hpp"
+#include "map/has.hpp"
 
 #include "array/ctor.hpp"
 #include "array/get.hpp"


### PR DESCRIPTION
I'd found using .find and then comparing the result to .end() too verbose, so I've added .has method to json_map that checks whether or not a map contains specific key.
It comes in two flavors: templated on expected value type and not - just like .get.
